### PR TITLE
gcr.io/google_containers/check-metadata-concealment:v0.0.2

### DIFF
--- a/test/Godeps/Godeps.json
+++ b/test/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "k8s.io/contrib/metadata-proxy/tmp",
+	"ImportPath": "github.com/GoogleCloudPlatform/k8s-metadata-proxy/test",
 	"GoVersion": "go1.9",
 	"GodepVersion": "v79",
 	"Deps": []

--- a/test/Makefile
+++ b/test/Makefile
@@ -17,7 +17,7 @@ all: build
 FLAGS =
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = gcr.io/google_containers
-TAG = v0.0.1
+TAG = v0.0.2
 
 deps:
 	go get github.com/tools/godep

--- a/test/check-metadata-concealment.yaml
+++ b/test/check-metadata-concealment.yaml
@@ -9,6 +9,6 @@ spec:
     spec:
       containers:
       - name: check-metadata-concealment
-        image: gcr.io/google_containers/check-metadata-concealment:v0.0.1
+        image: gcr.io/google_containers/check-metadata-concealment:v0.0.2
         imagePullPolicy: Always
       restartPolicy: Never


### PR DESCRIPTION
Bump test image to v0.0.2, once GoogleCloudPlatform/k8s-metadata-proxy#1 is in.