### PR TITLE
Make addresses configurable

### DIFF
--- a/metadata_proxy.go
+++ b/metadata_proxy.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"net/http"
 	"net/http/httputil"
@@ -43,17 +44,20 @@ var (
 )
 
 var (
+	addr                = flag.String("addr", "127.0.0.1:988", "Address at which to listen and proxy")
+	metricsAddr         = flag.String("metrics-addr", "127.0.0.1:989", "Address at which to publish metrics")
 	filterResultBlocked = "filter_result_blocked"
 	filterResultProxied = "filter_result_proxied"
 )
 
 func main() {
-	// TODO(ihmccreery) Make these ports configurable.
+	flag.Parse()
+
 	go func() {
-		err := http.ListenAndServe("127.0.0.1:989", promhttp.Handler())
+		err := http.ListenAndServe(*metricsAddr, promhttp.Handler())
 		log.Fatalf("Failed to start metrics: %v", err)
 	}()
-	log.Fatal(http.ListenAndServe("127.0.0.1:988", newMetadataHandler()))
+	log.Fatal(http.ListenAndServe(*addr, newMetadataHandler()))
 }
 
 // xForwardedForStripper is identical to http.DefaultTransport except that it


### PR DESCRIPTION
I'd like to switch around where the metrics are published, since 989 is actually [reserved for FTPS](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers#Well-known_ports).  Making these configurable in the PodSpec will make this transition possible.