### PR TITLE
Also block lookups of the service-account token

### DIFF
--- a/metadata_proxy.go
+++ b/metadata_proxy.go
@@ -24,6 +24,9 @@ var (
 		regexp.MustCompile("/0.1/meta-data/service-accounts/.+/identity"),
 		regexp.MustCompile("/computeMetadata/v1beta1/instance/service-accounts/.+/identity"),
 		regexp.MustCompile("/computeMetadata/v1/instance/service-accounts/.+/identity"),
+		regexp.MustCompile("/0.1/meta-data/service-accounts/.+/token"),
+		regexp.MustCompile("/computeMetadata/v1beta1/instance/service-accounts/.+/token"),
+		regexp.MustCompile("/computeMetadata/v1/instance/service-accounts/.+/token"),		
 	}
 	knownPrefixes = []string{
 		"/0.1/meta-data/",


### PR DESCRIPTION
Prevents: curl -H "X-Google-Metadata-Request: True" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
{"access_token":"LONGAPIBEARERTOKENHERE","expires_in":3387,"token_type":"Bearer"}