### PR TITLE
v0.1.7, test v0.0.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = gcr.io/google_containers
-TAG = v0.1.6
+TAG = v0.1.7
 
 deps:
 	go get github.com/tools/godep

--- a/test/Makefile
+++ b/test/Makefile
@@ -16,7 +16,7 @@ all: build
 
 ENVVAR = GOOS=linux GOARCH=amd64 CGO_ENABLED=0
 REGISTRY = gcr.io/google_containers
-TAG = v0.0.2
+TAG = v0.0.3
 
 deps:
 	go get github.com/tools/godep


### PR DESCRIPTION
Release now that https://github.com/GoogleCloudPlatform/k8s-metadata-proxy/pull/13 is in.