### PR TITLE
Fix default build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ TAG = v0.1.9
 
 deps:
 	go get github.com/tools/godep
-	godep save
 
 build: clean deps
 	$(ENVVAR) godep go test ./...


### PR DESCRIPTION
Make should not run godep save by default. Godep save takes the version of all dependencies in the users $GOPATH and copies them under vender/, and throws and error if any of the dependencies are not installed under $GOPATH